### PR TITLE
add vcpkg support for 'easier' dependency management on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vcpkg_installed
+build

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "2c401863dd54a640aeb26ed736c55489c079323b",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": [
+    "spirv-headers",
+    "json-c",
+    "llvm",
+    "vulkan"
+  ]
+}


### PR DESCRIPTION
Not sure if this is something that you want to include, but even if you don't it may be helpful for other people looking to try Shady without manually installing the dependencies.

Usage:
- install the vcpkg tools included with visual studio (tested on VS2022)
  ![image](https://github.com/shady-gang/shady/assets/46673/376126d4-954e-4c70-bdba-f4bfec08f41c)

- install the [vulkan sdk](https://vulkan.lunarg.com/sdk/home)

```
cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE="C:/Program Files/Microsoft Visual Studio/2022/Community/VC/vcpkg/scripts/buildsystems/vcpkg.cmake"

cmake --build build
build/
```

```
C:\Users\tmpva\dev\shady>build\bin\debug\checkerboard.exe
Shady checkerboard test starting...
Enabling validation...
Enabling instance extension VK_KHR_get_physical_device_properties2
Enabling instance extension VK_EXT_debug_utils
Enabling instance extension VK_KHR_portability_enumeration
Initialising device NVIDIA GeForce RTX 3070
Validation says: Inserted device layer "VK_LAYER_KHRONOS_validation" (C:\VulkanSDK\1.3.275.0\Bin\.\VkLayer_khronos_validation.dll)
Validation says: Inserted device layer "VK_LAYER_OBS_HOOK" (C:\ProgramData\obs-studio-hook\.\graphics-hook64.dll)
Validation says: Inserted device layer "VK_LAYER_NV_optimus" (C:\Windows\System32\DriverStore\FileRepository\nv_dispi.inf_amd64_8f4dab92e290c42d\.\nvoglv64.dll)
Validation says:        Using "NVIDIA GeForce RTX 3070" with driver: "C:\Windows\System32\DriverStore\FileRepository\nv_dispi.inf_amd64_8f4dab92e290c42d\.\nvoglv64.dll"
Validation says: Validation Information: [ WARNING-cache-file-error ] | MessageID = 0xb8515d13 | vkCreateDevice():  Cannot open shader validation cache at C:\Users\tmpva\AppData\Local\Temp/shader_validation_cache.bin for reading (it may not exist yet)
Found 1 usable devices
Shady Vulkan backend successfully initialized !
Shady runtime successfully initialized !
malloc'd address is: 1820037095360
Validation says: Validation Error: [ VUID-vkGetMemoryHostPointerPropertiesEXT-pHostPointer-01753 ] | MessageID = 0x4c8d30c1 | vkGetMemoryHostPointerPropertiesEXT(): pHostPointer (0x1a7c2aa1fc0) is not aligned to minImportedHostPointerAlignment (4096). The Vulkan spec states: pHostPointer must be a pointer aligned to an integer multiple of VkPhysicalDeviceExternalMemoryHostPropertiesEXT::minImportedHostPointerAlignment (https://vulkan.lunarg.com/doc/view/1.3.275.0/windows/1.3-extensions/vkspec.html#VUID-vkGetMemoryHostPointerPropertiesEXT-pHostPointer-01753)
Device-side address is: 204079104
Validation says: Validation Error: [ VUID-vkGetMemoryHostPointerPropertiesEXT-pHostPointer-01753 ] | MessageID = 0x4c8d30c1 | vkGetMemoryHostPointerPropertiesEXT(): pHostPointer (0x1a7c2aa1fc0) is not aligned to minImportedHostPointerAlignment (4096). The Vulkan spec states: pHostPointer must be a pointer aligned to an integer multiple of VkPhysicalDeviceExternalMemoryHostPropertiesEXT::minImportedHostPointerAlignment (https://vulkan.lunarg.com/doc/view/1.3.275.0/windows/1.3-extensions/vkspec.html#VUID-vkGetMemoryHostPointerPropertiesEXT-pHostPointer-01753)
data 0
```