### PR TITLE
fix CUDA

### DIFF
--- a/src/shady/emit/c/emit_c.c
+++ b/src/shady/emit/c/emit_c.c
@@ -396,7 +396,6 @@ void emit_variable_declaration(Emitter* emitter, Printer* block_printer, const T
             break;
         case CDialect_C11:
         case CDialect_CUDA:
-            prefix = "register ";
             center = format_string_arena(emitter->arena->arena, "const %s", center);
             break;
         case CDialect_GLSL:

--- a/src/shady/emit/c/emit_c_signatures.c
+++ b/src/shady/emit/c/emit_c_signatures.c
@@ -160,7 +160,7 @@ String emit_type(Emitter* emitter, const Type* type, const char* center) {
                             { "unsigned char" , "char"  },
                             { "unsigned short", "short" },
                             { "unsigned int"  , "int" },
-                            { "unsigned long" , "long" },
+                            { "unsigned long long" , "long long" },
                     };
                     const char* c_explicit_int_sizes[4][2] = {
                             { "uint8_t" , "int8_t"  },


### PR DESCRIPTION
* Remove `register` keyword from variable declarations as NVRTC will otherwise complain starting with CUDA 12 (due to default C++ version bumped to 17).
* Change 64-bit type to `unsigned long long` since `unsigned long` is 32-bit on Windows.