### PR TITLE
fix windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ if (MSVC)
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()
 
+if (WIN32)
+  set(BUILD_SHARED_LIBS OFF)
+endif()
+
 add_subdirectory(SPIRV-Headers)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")

--- a/src/common/portability.h
+++ b/src/common/portability.h
@@ -20,7 +20,7 @@ static_assert(__STDC_VERSION__ >= 201112L, "C11 support is required to build sha
     #define SHADY_FALLTHROUGH
     // It's mid 2022, and this typedef is missing from <stdalign.h>
     // MSVC is not a real C11 compiler.
-    typedef long long max_align_t;
+    typedef double max_align_t;
 #else
     #ifdef USE_VLAS
         #define LARRAY(T, name, size) T name[size]


### PR DESCRIPTION
* change `max_align_t` compatibility typedef to `double` as required per Windows ABI (caused build failure on clang-cl)
* turn off BUILD_SHARED_LIBS to avoid linker issues