### PR TITLE
fix build on non-C23 compilers

### DIFF
--- a/src/runtime/runtime_cli.c
+++ b/src/runtime/runtime_cli.c
@@ -8,6 +8,8 @@ RuntimeConfig default_runtime_config() {
 #ifndef NDEBUG
         .dump_spv = true,
         .use_validation = true,
+#else
+        0
 #endif
     };
 }


### PR DESCRIPTION
Replace empty initialization with `{0}` since it's a C23 feature that MSVC doesn't support (lol).