### PR TITLE
Fixes "error: no such file" when using --dump-ir

### DIFF
--- a/src/driver/cli.c
+++ b/src/driver/cli.c
@@ -258,10 +258,6 @@ void shd_parse_driver_args(DriverConfig* args, int* pargc, char** argv) {
                 exit(ShdMissingOutputArg);
             }
             args->output_filename = argv[i];
-        } else if (strcmp(argv[i], "--dump-ir") == 0) {
-            argv[i] = NULL;
-            args->dump_ir = true;
-            continue;
         } else if (strcmp(argv[i], "--dump-cfg") == 0) {
             argv[i] = NULL;
             i++;


### PR DESCRIPTION
Looks like it was treating "dump.txt" as an input file. Removing the duplicate check for --dump-ir fixed it for me, but not sure if this is the correct fix.

```
C:\Users\Bjorn\projects\code\shady>vcc --rtlib=compiler-rt -I"%SHADY_INCLUDE_DIR%"  -o output.spv test\vcc\textured.frag.c --dump-ir dump.txt
clang version 20.1.8
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\Program Files\LLVM\bin
file=test\vcc\textured.frag.c tmpfile=YxF1N1OSdKkyybRybFw5cMAsPYpm2Vw1
built command: clang -c -emit-llvm -S -g -O0 -ffreestanding -Wno-main-return-type -isystem"C:\Users\Bjorn\projects\code\shady\build\bin\Debug/../share/vcc/include/" -D__SHADY__=1 --target=spirv64-unknown-unknown -o YxF1N1OSdKkyybRybFw5cMAsPYpm2Vw1 "test\vcc\textured.frag.c" "--rtlib=compiler-rt" "-IC:\Users\Bjorn\projects\code\shady\build\share\vcc\include"
clang: warning: argument unused during compilation: '-c' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '--rtlib=compiler-rt' [-Wunused-command-line-argument]
Clang returned 0 and replied:
LLVM IR parsed successfully
built command: clang -c -emit-llvm -S -g -O0 -ffreestanding -Wno-main-return-type -isystem"C:\Users\Bjorn\projects\code\shady\build\bin\Debug/../share/vcc/include/" -D__SHADY__=1 --target=spirv64-unknown-unknown -o YxF1N1OSdKkyybRybFw5cMAsPYpm2Vw1 "dump.txt" "--rtlib=compiler-rt" "-IC:\Users\Bjorn\projects\code\shady\build\share\vcc\include"
clang: error: no such file or directory: 'dump.txt'
clang: error: no input files
Clang returned 1 and replied:
```